### PR TITLE
Allow leaving conversations

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,6 +21,12 @@ service cloud.firestore {
       allow delete: if false;
       allow read: if request.auth.uid in resource.data.uids;
 
+      // messages can be created and read by conversation participants 
+      // see: https://firebase.google.com/docs/firestore/solutions/role-based-access
+      match /leave/{userId} {
+        allow create: if request.auth.uid == userId;
+      }
+
 			// messages can be created and read by conversation participants 
       // see: https://firebase.google.com/docs/firestore/solutions/role-based-access
       match /messages/{messageId} {

--- a/lib/actions/conversations/leave_conversation.dart
+++ b/lib/actions/conversations/leave_conversation.dart
@@ -1,0 +1,34 @@
+library leave_conversation;
+
+import 'dart:convert';
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'package:crowdleague/actions/redux_action.dart';
+import 'package:crowdleague/models/app/serializers.dart';
+
+part 'leave_conversation.g.dart';
+
+abstract class LeaveConversation extends Object
+    with ReduxAction
+    implements Built<LeaveConversation, LeaveConversationBuilder> {
+  String get conversationId;
+
+  LeaveConversation._();
+
+  factory LeaveConversation([void Function(LeaveConversationBuilder) updates]) =
+      _$LeaveConversation;
+
+  Object toJson() =>
+      serializers.serializeWith(LeaveConversation.serializer, this);
+
+  static LeaveConversation fromJson(String jsonString) => serializers
+      .deserializeWith(LeaveConversation.serializer, json.decode(jsonString));
+
+  static Serializer<LeaveConversation> get serializer =>
+      _$leaveConversationSerializer;
+
+  @override
+  String toString() => 'LEAVE_CONVERSATION: id=$conversationId';
+}

--- a/lib/middleware/conversations_middleware.dart
+++ b/lib/middleware/conversations_middleware.dart
@@ -1,5 +1,6 @@
 import 'package:crowdleague/actions/conversations/create_conversation.dart';
 import 'package:crowdleague/actions/conversations/disregard_messages.dart';
+import 'package:crowdleague/actions/conversations/leave_conversation.dart';
 import 'package:crowdleague/actions/conversations/observe_messages.dart';
 import 'package:crowdleague/actions/conversations/retrieve_conversation_summaries.dart';
 import 'package:crowdleague/actions/conversations/save_message.dart';
@@ -21,6 +22,8 @@ typedef ObserveMessagesMiddleware = void Function(
     Store<AppState> store, ObserveMessages action, NextDispatcher next);
 typedef DisregardMessagesMiddleware = void Function(
     Store<AppState> store, DisregardMessages action, NextDispatcher next);
+typedef LeaveConversationMiddleware = void Function(
+    Store<AppState> store, LeaveConversation action, NextDispatcher next);
 
 /// Middleware is used for a variety of things:
 /// - Logging
@@ -48,6 +51,9 @@ List<Middleware<AppState>> createConversationsMiddleware(
     ),
     TypedMiddleware<AppState, DisregardMessages>(
       _disregardMessages(conversationsService),
+    ),
+    TypedMiddleware<AppState, LeaveConversation>(
+      _leaveConversation(conversationsService),
     ),
   ];
 }
@@ -117,5 +123,18 @@ DisregardMessagesMiddleware _disregardMessages(
     /// the function calls listen on the firestore and keeps the stream open
     /// until disregardMessages is called
     conversationService.disregardMessages(store);
+  };
+}
+
+LeaveConversationMiddleware _leaveConversation(
+    ConversationsService conversationService) {
+  return (Store<AppState> store, LeaveConversation action,
+      NextDispatcher next) async {
+    next(action);
+
+    /// returns a Future<void>, currently no need to do anything when the
+    /// future completes as the list has been updated locally already
+    await conversationService.leaveConversation(
+        store.state.user.id, action.conversationId);
   };
 }

--- a/lib/models/app/serializers.dart
+++ b/lib/models/app/serializers.dart
@@ -6,6 +6,7 @@ import 'package:crowdleague/actions/auth/sign_out_user.dart';
 import 'package:crowdleague/actions/auth/store_user.dart';
 import 'package:crowdleague/actions/conversations/create_conversation.dart';
 import 'package:crowdleague/actions/conversations/disregard_messages.dart';
+import 'package:crowdleague/actions/conversations/leave_conversation.dart';
 import 'package:crowdleague/actions/conversations/observe_messages.dart';
 import 'package:crowdleague/actions/conversations/retrieve_conversation_summaries.dart';
 import 'package:crowdleague/actions/conversations/store_conversation_summaries.dart';
@@ -81,6 +82,7 @@ part 'serializers.g.dart';
   StoreNavBarSelection,
   StoreConversationSummaries,
   StoreSelectedConversation,
+  LeaveConversation,
   UpdateNewConversationPage,
   RetrieveLeaguers,
   StoreLeaguers,

--- a/lib/reducers/conversations_reducers.dart
+++ b/lib/reducers/conversations_reducers.dart
@@ -1,3 +1,4 @@
+import 'package:crowdleague/actions/conversations/leave_conversation.dart';
 import 'package:crowdleague/actions/conversations/store_conversation_summaries.dart';
 import 'package:crowdleague/actions/conversations/store_messages.dart';
 import 'package:crowdleague/actions/conversations/store_selected_conversation.dart';
@@ -17,6 +18,7 @@ final conversationsReducers = <AppState Function(AppState, dynamic)>[
   TypedReducer<AppState, StoreSelectedConversation>(_storeSelectedConversation),
   TypedReducer<AppState, StoreMessages>(_storeMessages),
   TypedReducer<AppState, UpdateConversationPage>(_updateConversationPage),
+  TypedReducer<AppState, LeaveConversation>(_leaveConversation),
 ];
 
 AppState _storeConversationSummaries(
@@ -54,4 +56,10 @@ AppState _updateConversationPage(
     AppState state, UpdateConversationPage action) {
   return state
       .rebuild((b) => b..conversationPage.messageText = action.messageText);
+}
+
+AppState _leaveConversation(AppState state, LeaveConversation action) {
+  return state.rebuild((b) => b
+    ..conversationSummariesPage.summaries.removeWhere(
+        (summary) => summary.conversationId == action.conversationId));
 }

--- a/lib/services/conversations_service.dart
+++ b/lib/services/conversations_service.dart
@@ -157,4 +157,10 @@ class ConversationsService {
           AddProblemObject.from(error, trace, ProblemType.disregardMessages));
     }
   }
+
+  Future<void> leaveConversation(String userId, String conversationId) {
+    return firestore
+        .document('conversations/$conversationId/leave/$userId')
+        .setData(<String, dynamic>{'timestamp': FieldValue.serverTimestamp()});
+  }
 }

--- a/lib/widgets/conversations/conversation_summaries/conversation_summary_tile.dart
+++ b/lib/widgets/conversations/conversation_summaries/conversation_summary_tile.dart
@@ -1,3 +1,4 @@
+import 'package:crowdleague/actions/conversations/leave_conversation.dart';
 import 'package:crowdleague/actions/conversations/store_selected_conversation.dart';
 import 'package:crowdleague/actions/navigation/navigate_to.dart';
 import 'package:crowdleague/models/conversations/conversation_summary.dart';
@@ -12,14 +13,27 @@ class ConversationSummaryTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      leading: Image.network(summary.photoURLs.first),
-      title: Text(summary.displayNames.first),
-      onTap: () {
-        context.dispatch(
-            StoreSelectedConversation((b) => b..summary.replace(summary)));
-        context.dispatch(NavigateTo((b) => b..location = '/conversation'));
+    return Dismissible(
+      // Show a red background as the item is swiped away.
+      background: Container(color: Colors.red),
+      key: Key(summary.conversationId),
+      onDismissed: (direction) {
+        context.dispatch(LeaveConversation(
+            (b) => b..conversationId = summary.conversationId));
+
+        Scaffold.of(context).showSnackBar(SnackBar(
+            content: Text(
+                'Leaving conversation with id: ${summary.conversationId}')));
       },
+      child: ListTile(
+        leading: Image.network(summary.photoURLs.first),
+        title: Text(summary.displayNames.first),
+        onTap: () {
+          context.dispatch(
+              StoreSelectedConversation((b) => b..summary.replace(summary)));
+          context.dispatch(NavigateTo((b) => b..location = '/conversation'));
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
Fixes #78

- action: leave_conversation
- middleware: _leaveConversation (updates firestore)
- reducers: _leaveConversation (updates local state)
- services: ConversationService.leaveConversation
- added a cloud function to update the conversation doc
- widgets: added swipe to dismiss to tiles that dispatches
LeaveConversation
- updated firestore rules to allow doc creation in conversations/_/leave